### PR TITLE
Ignore 'curl: Empty reply from server' error upon termination

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,13 @@ It is enough to send `_TERMINATE` request to a server:
 curl -X_TERMINATE localhost:9977
 ```
 
+This command may fail with `curl: (52) Empty reply from server`, which should
+not be a problem, and typically should be ignored:
+
+```bash
+curl -X_TERMINATE localhost:9977 || true
+```
+
 ### Expectations
 
 #### Expect equal last recorded data

--- a/tests/lib.sh
+++ b/tests/lib.sh
@@ -21,7 +21,7 @@ setup() {
 }
 
 cleanup() {
-  curl -X_TERMINATE localhost:9977
+  curl -X_TERMINATE localhost:9977 || true
   ./recorder reset
 }
 


### PR DESCRIPTION
Fixes #9 
