### PR TITLE
Create /tmp/.recorder directory beforehand to avoid permission denied…

### DIFF
--- a/dockerfiles/runner.sh
+++ b/dockerfiles/runner.sh
@@ -15,6 +15,8 @@ fi
 
 dir_opts="-v /tmp/.recorder:/tmp/.recorder -w /tmp"
 
+mkdir -p /tmp/.recorder
+
 docker run \
   $need_user \
   $dir_opts \


### PR DESCRIPTION
… with docker wrapper script

Fixed #18
